### PR TITLE
chore: release v0.1.0

### DIFF
--- a/instrumentRs/CHANGELOG.md
+++ b/instrumentRs/CHANGELOG.md
@@ -1,0 +1,20 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0](https://github.com/trappitsch/instrumentRs/releases/tag/instrumentrs-v0.1.0) - 2025-07-22
+
+### Other
+
+- revamp workspace
+- Extend test suite for `InstrumentRs`
+- add examples and extend docs for both instruments and instrumentrs
+- Restructure to allow any interface with Read+Write, add simplified Serial,TCP/IP
+- Further dev on InstrumentRs and Pfeiffer TPG 36x integration ([#1](https://github.com/trappitsch/instrumentRs/pull/1))
+- add pre-commit and ci workflow
+- A first InstrumenRs version with error, channel, and test handling

--- a/other/digoutbox/CHANGELOG.md
+++ b/other/digoutbox/CHANGELOG.md
@@ -1,0 +1,18 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0](https://github.com/trappitsch/instrumentRs/releases/tag/digoutbox-v0.1.0) - 2025-07-22
+
+### Other
+
+- revamp workspace
+- add examples and extend docs for both instruments and instrumentrs
+- Restructure to allow any interface with Read+Write, add simplified Serial,TCP/IP
+- Further dev on InstrumentRs and Pfeiffer TPG 36x integration ([#1](https://github.com/trappitsch/instrumentRs/pull/1))
+- restructure digoutbox into `other` category, rename examples

--- a/pfeiffer/tpg36x/CHANGELOG.md
+++ b/pfeiffer/tpg36x/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0](https://github.com/trappitsch/instrumentRs/releases/tag/pfeiffer-tpg36x-v0.1.0) - 2025-07-22
+
+### Other
+
+- revamp workspace
+- add examples and extend docs for both instruments and instrumentrs
+- Restructure to allow any interface with Read+Write, add simplified Serial,TCP/IP
+- Further dev on InstrumentRs and Pfeiffer TPG 36x integration ([#1](https://github.com/trappitsch/instrumentRs/pull/1))


### PR DESCRIPTION



## 🤖 New release

* `instrumentrs`: 0.1.0
* `digoutbox`: 0.1.0
* `pfeiffer-tpg36x`: 0.1.0

<details><summary><i><b>Changelog</b></i></summary><p>

## `instrumentrs`

<blockquote>

## [0.1.0](https://github.com/trappitsch/instrumentRs/releases/tag/instrumentrs-v0.1.0) - 2025-07-22

### Other

- revamp workspace
- Extend test suite for `InstrumentRs`
- add examples and extend docs for both instruments and instrumentrs
- Restructure to allow any interface with Read+Write, add simplified Serial,TCP/IP
- Further dev on InstrumentRs and Pfeiffer TPG 36x integration ([#1](https://github.com/trappitsch/instrumentRs/pull/1))
- add pre-commit and ci workflow
- A first InstrumenRs version with error, channel, and test handling
</blockquote>

## `digoutbox`

<blockquote>

## [0.1.0](https://github.com/trappitsch/instrumentRs/releases/tag/digoutbox-v0.1.0) - 2025-07-22

### Other

- revamp workspace
- add examples and extend docs for both instruments and instrumentrs
- Restructure to allow any interface with Read+Write, add simplified Serial,TCP/IP
- Further dev on InstrumentRs and Pfeiffer TPG 36x integration ([#1](https://github.com/trappitsch/instrumentRs/pull/1))
- restructure digoutbox into `other` category, rename examples
</blockquote>

## `pfeiffer-tpg36x`

<blockquote>

## [0.1.0](https://github.com/trappitsch/instrumentRs/releases/tag/pfeiffer-tpg36x-v0.1.0) - 2025-07-22

### Other

- revamp workspace
- add examples and extend docs for both instruments and instrumentrs
- Restructure to allow any interface with Read+Write, add simplified Serial,TCP/IP
- Further dev on InstrumentRs and Pfeiffer TPG 36x integration ([#1](https://github.com/trappitsch/instrumentRs/pull/1))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).